### PR TITLE
Fixed path separators on windows

### DIFF
--- a/skydrive/api_v5.py
+++ b/skydrive/api_v5.py
@@ -11,7 +11,7 @@ import operator as op
 import functools as ft
 
 from datetime import datetime, timedelta
-from os.path import join, basename
+from posixpath import join, basename
 
 from skydrive.conf import ConfigMixin
 


### PR DESCRIPTION
os.path uses the local OS directory separator ('\'), while posixpath always uses '/'. For web URLs we of course always want '/'.
