### PR TITLE
BITS: Calculate the number of fragments correctly if src_len is multiple of frag_bytes.

### DIFF
--- a/onedrive/api_v5.py
+++ b/onedrive/api_v5.py
@@ -466,7 +466,7 @@ class OneDriveAPIWrapper(OneDriveAuth):
 		src.seek(0, os.SEEK_END)
 		c, src_len = 0, src.tell()
 		cn = src_len / frag_bytes
-		if c * cn != src_len: cn += 1
+		if frag_bytes * cn != src_len: cn += 1
 		src.seek(0)
 		for n in xrange(1, cn+1):
 			log.debug( 'Uploading BITS fragment'


### PR DESCRIPTION
Previously one fragment was unconditionally added to the number of fragments because `c*cn` was always zero but `src_len` most likely wasn't. In case the upload size was multiple of frag_bytes the request sent for the last fragment contained an invalid Content-Range header and the entire upload failed with protocol error.

Fixes #41.
