### PR TITLE
use utf8 encoding by default

### DIFF
--- a/onedrive/cli_tool.py
+++ b/onedrive/cli_tool.py
@@ -7,6 +7,8 @@ from os.path import dirname, basename, exists, isdir, join, abspath
 from posixpath import join as ujoin, dirname as udirname, basename as ubasename
 from collections import defaultdict
 import os, sys, io, logging, re, types, json
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 try: import chardet
 except ImportError: chardet = None # completely optional


### PR DESCRIPTION
I came across an issue when getting a file containing non-ASCII characters.

    Traceback (most recent call last):
      File "./onedrive-cli", line 399, in <module>
        if __name__ == '__main__': main()
      File "./onedrive-cli", line 356, in main
        sys.stdout.write(contents)
      File "/usr/lib/python2.7/codecs.py", line 351, in write
        data, consumed = self.encode(object, self.errors)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 99: ordinal not in range(128)

