### PR TITLE
add callback function to put_bits method

### DIFF
--- a/onedrive/api_v5.py
+++ b/onedrive/api_v5.py
@@ -458,12 +458,14 @@ class OneDriveAPIWrapper(OneDriveAuth):
 			data=src, method='put', auth_header=True )
 
 	def put_bits( self, path_or_tuple,
-			folder_id=None, folder_path=None, frag_bytes=None, raw_id=False ):
+			folder_id=None, folder_path=None, frag_bytes=None, raw_id=False, callback=None ):
 		'''Upload a file (object) using BITS API (via several http requests), possibly
 				overwriting (default behavior) a file with the same "name" attribute, if it exists.
 
 			Unlike "put" method, uploads to "folder_path" (instead of folder_id) are
 				supported here. Either folder path or id can be specified, but not both.
+				If "callback" is provided it will be called everytime a chunk has been
+				uploaded with the current offset and source length.
 
 			Returns id of the uploaded file, as retured by the API
 				if raw_id=True is passed, otherwise in a consistent (with other calls)
@@ -528,6 +530,9 @@ class OneDriveAPIWrapper(OneDriveAuth):
 					'BITS-Session-Id': bits_sid,
 					'Content-Range': 'bytes {}-{}/{}'.format(c, min(c1, src_len)-1, src_len) })
 			c = c1
+
+			if callback:
+				callback(c, src_len)
 
 		if self.api_bits_auth_refresh_before_commit_hack:
 			# As per #39 and comments under the gist with the spec,


### PR DESCRIPTION
It is no problem to do a chunked upload using the `put_bits` method, but I need to do some tasks between chunk uploads (status update and similar). This pull-requests adds an optional callback to the method which will take transferred bytes and total bytes as arguments.

```python
def my_callback(bytes_transferred, bytes_total):
    print "uploaded: {}%".format(bytes_transferred * 100 / bytes_total)
```