### PR TITLE
fix for reading uppercase bits-session-id from headers

### DIFF
--- a/onedrive/api_v5.py
+++ b/onedrive/api_v5.py
@@ -511,10 +511,11 @@ class OneDriveAPIWrapper(OneDriveAuth):
 		h = lambda k,hs=dict((k.lower(), v) for k,v in headers.viewitems()): hs.get(k, '')
 		checks = [ code == 201,
 			h('bits-packet-type').lower() == 'ack',
-			h('bits-protocol').lower() == self.api_bits_protocol_id.lower() ]
+			h('bits-protocol').lower() == self.api_bits_protocol_id.lower(),
+			h('bits-session-id') ]
 		if not all(checks):
 			raise ProtocolError(code, 'Invalid BITS Create-Session response', headers, body, checks)
-		bits_sid = headers['bits-session-id']
+		bits_sid = h('bits-session-id')
 
 		src.seek(0, os.SEEK_END)
 		c, src_len = 0, src.tell()


### PR DESCRIPTION
When api.put_bits was called, an uncaught KeyError was being thrown by this library:
```
Traceback (most recent call last):
  File "/usr/local/bin/onedrive-upload", line 31, in upload_files
    api.put_bits(path, folder_id=skydrive_path)
  File "/usr/local/lib/python2.7/dist-packages/onedrive/api_v5.py", line 518,
 put_bits
    bits_sid = headers['bits-session-id']
KeyError: u'bits-session-id'
```

Upon further inspection, this was due to "bits-session-id" being represented as "BITS-Session-Id" by the server, breaking this library.

I've made a change to account for that capitalization, and throw a more appropriate error if this key isn't found in the response header.

Testing done:
Uploaded large file (1.9Gb) using put_bits. Unrelated errors "Error 500: Internal Server Error", "Error 100: Connection timed out" were encountered, but upload succeeded eventually after several retries. No errors were observed due specifically to this change.
