### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ without any installation, if that's the only thing you need there.
 
 * (optional) [chardet](http://pypi.python.org/pypi/chardet) - only used to
 	detect encoding (utf-8, gbk, koi8-r, etc) of the command-line arguments to
-	support workng with non-ascii (e.g. cyrillic, chinese) names, if explicitly
+	support working with non-ascii (e.g. cyrillic, chinese) names, if explicitly
 	requested.
 
 	Not needed unless you specifically use cli tool with "--encoding detect"
@@ -367,10 +367,10 @@ It's quite a conventional REST API with JSON encoding of structured data, like
 pretty much every other trendy modern API, say, github.
 
 Authentication is ["OAuth 2.0"](http://msdn.microsoft.com/en-us/library/dn659750.aspx),
-which is quite ambigous all by itself, and especially when being implemented by
+which is quite ambiguous all by itself, and especially when being implemented by
 well-known for it's proprietary "cripple-everything-else" extension creep
 Microsoft.
-It has a twist in authrization_code grant flow for "mobile" apps, where bearer
+It has a twist in authorization_code grant flow for "mobile" apps, where bearer
 token refresh can be performed without having to provide client_secret. Client
 app must be marked as "mobile" in
 [DevCenter](https://account.live.com/developers/applications/create)

--- a/doc/api.md
+++ b/doc/api.md
@@ -33,7 +33,7 @@
 
         Make synchronous HTTP request.
 
-        Can be overidden to use different http module (e.g. urllib2,
+        Can be overridden to use different http module (e.g. urllib2,
         twisted, etc).
 
 
@@ -238,7 +238,7 @@
         upload state and BITS session info required to resume it, if
         necessary.
 
-        Returns id of the uploaded file, as retured by the API if
+        Returns id of the uploaded file, as returned by the API if
         raw_id=True is passed, otherwise in a consistent (with other
         calls) "file.{user_id}.{file_id}" format (default).
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,7 @@ doc_root = dirname(__file__)
 
 os.chdir(doc_root)
 sys.path.insert(0, abspath('..')) # for module itself
-sys.path.append(abspath('.')) # for extenstions
+sys.path.append(abspath('.')) # for extensions
 
 needs_sphinx = '1.1'
 extensions = ['sphinx.ext.autodoc', 'sphinx_local_hooks']

--- a/onedrive/api_v5.py
+++ b/onedrive/api_v5.py
@@ -148,7 +148,7 @@ class OneDriveHTTPClient(object):
 	def request( self, url, method='get', data=None, files=None,
 				raw=False, raw_all=False, headers=dict(), raise_for=dict(), session=None ):
 		'''Make synchronous HTTP request.
-			Can be overidden to use different http module (e.g. urllib2, twisted, etc).'''
+			Can be overridden to use different http module (e.g. urllib2, twisted, etc).'''
 		try: import requests # import here to avoid dependency on the module
 		except ImportError as exc:
 			exc.args = ( 'Unable to find/import "requests" module.'
@@ -495,7 +495,7 @@ class OneDriveAPIWrapper(OneDriveAuth):
 				uploaded chunk with keyword parameters corresponding to
 				upload state and BITS session info required to resume it, if necessary.
 
-			Returns id of the uploaded file, as retured by the API
+			Returns id of the uploaded file, as returned by the API
 				if raw_id=True is passed, otherwise in a consistent (with other calls)
 				"file.{user_id}.{file_id}" format (default).'''
 		# XXX: overwrite/downsize are not documented/supported here (yet?)


### PR DESCRIPTION
There are small typos in:
- README.md
- doc/api.md
- doc/conf.py
- onedrive/api_v5.py

Fixes:
- Should read `returned` rather than `retured`.
- Should read `overridden` rather than `overidden`.
- Should read `working` rather than `workng`.
- Should read `extensions` rather than `extenstions`.
- Should read `authorization` rather than `authrization`.
- Should read `ambiguous` rather than `ambigous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md